### PR TITLE
Fix enchantment status

### DIFF
--- a/src/main/java/cz/kominekjan/disenchantment/Disenchantment.java
+++ b/src/main/java/cz/kominekjan/disenchantment/Disenchantment.java
@@ -54,7 +54,7 @@ public final class Disenchantment extends JavaPlugin {
         File configFile = new File(plugin.getDataFolder(), "config.yml");
 
         try {
-            ConfigUpdater.update(plugin, "config.yml", configFile);
+            ConfigUpdater.update(plugin, "config.yml", configFile, "enchantments-status", "book-splitting-enchantments-status");
         } catch (IOException e) {
             logger.warning(Arrays.toString(e.getStackTrace()));
         }

--- a/src/main/java/cz/kominekjan/disenchantment/Disenchantment.java
+++ b/src/main/java/cz/kominekjan/disenchantment/Disenchantment.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static cz.kominekjan.disenchantment.config.Config.setPluginEnabled;
@@ -54,9 +55,13 @@ public final class Disenchantment extends JavaPlugin {
         File configFile = new File(plugin.getDataFolder(), "config.yml");
 
         try {
-            ConfigUpdater.update(plugin, "config.yml", configFile, "enchantments-status", "book-splitting-enchantments-status");
+            ConfigUpdater.update(plugin, "config.yml", configFile,
+                    "enchantments-status", "book-splitting-enchantments-status",
+                    "disabled-enchantments", "disabled-book-splitting-enchantments");
         } catch (IOException e) {
             logger.warning(Arrays.toString(e.getStackTrace()));
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "could not update configuration", e);
         }
 
         plugin.reloadConfig();

--- a/src/main/java/cz/kominekjan/disenchantment/commands/CommandCompleter.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/CommandCompleter.java
@@ -53,6 +53,7 @@ public class CommandCompleter implements TabCompleter {
                     }
                     return result;
                 case "enchantments":
+                case "split-enchantments":
                     for (Enchantment enchantment : Registry.ENCHANTMENT) {
                         if (enchantment.getKey().getKey().toLowerCase().startsWith(args[1].toLowerCase())) {
                             result.add(enchantment.getKey().getKey());

--- a/src/main/java/cz/kominekjan/disenchantment/commands/CommandRegister.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/CommandRegister.java
@@ -19,8 +19,8 @@ public class CommandRegister implements CommandExecutor {
         commands.put("repair", Repair.command);
         commands.put("sound", Sound.command);
         commands.put("materials", Materials.command);
-        commands.put("enchantments", Enchantments.disenchantCommand);
-        commands.put("split-enchantments", Enchantments.bookSplittingCommand);
+        commands.put("enchantments", Enchantments.command);
+        commands.put("book_split_enchantments", BookSplitEnchantments.command);
         commands.put("gui", GUI.command);
     }
 

--- a/src/main/java/cz/kominekjan/disenchantment/commands/CommandRegister.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/CommandRegister.java
@@ -19,7 +19,8 @@ public class CommandRegister implements CommandExecutor {
         commands.put("repair", Repair.command);
         commands.put("sound", Sound.command);
         commands.put("materials", Materials.command);
-        commands.put("enchantments", Enchantments.command);
+        commands.put("enchantments", Enchantments.disenchantCommand);
+        commands.put("split-enchantments", Enchantments.bookSplittingCommand);
         commands.put("gui", GUI.command);
     }
 

--- a/src/main/java/cz/kominekjan/disenchantment/commands/impl/BookSplitEnchantments.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/impl/BookSplitEnchantments.java
@@ -14,21 +14,22 @@ import java.util.Map;
 
 import static cz.kominekjan.disenchantment.utils.TextUtils.*;
 
-public class Enchantments {
+public class BookSplitEnchantments {
+
     public static final Command command = new Command(
-            "enchantments",
+            "book_split_enchantments",
             new String[]{"disenchantment.all", "disenchantment.command.enchantments"},
             "You don't have permission to use this command.",
             new String[]{},
             false,
-            Enchantments::execute
+            BookSplitEnchantments::execute
     );
 
     public static void execute(CommandSender s, String[] args) {
-        Map<Enchantment, EnchantmentStatus> enchantmentStatus = Config.getEnchantmentsStatus();
+        Map<Enchantment, EnchantmentStatus> enchantmentStatus = Config.getBookSplittingEnchantmentsStatus();
 
         if (args.length == 1) {
-            s.sendMessage(textWithPrefix("Disabled enchantments for disenchanting"));
+            s.sendMessage(textWithPrefix("Disabled enchantments for book splitting"));
             s.sendMessage("");
 
             List<Enchantment> nonEnabledEnchantments = enchantmentStatus.entrySet().stream()
@@ -36,7 +37,7 @@ public class Enchantments {
                     .map(Map.Entry::getKey).toList();
 
             if (nonEnabledEnchantments.isEmpty()) {
-                s.sendMessage(ChatColor.GRAY + "No enchantments are disabled or set to being kept for disenchanting");
+                s.sendMessage(ChatColor.GRAY + "No enchantments are disabled or set to being kept for book splitting ");
                 return;
             }
 
@@ -80,9 +81,9 @@ public class Enchantments {
             return;
         }
 
-        s.sendMessage(textWithPrefixSuccess("Enchantment status set to " + selectedStatus.getDisplayName() + " for disenchantment"));
+        s.sendMessage(textWithPrefixSuccess("Enchantment status set to " + selectedStatus.getDisplayName() + " for book splitting"));
 
-        Config.setEnchantmentsStatus(enchantment, selectedStatus);
+        Config.setBookSplittingEnchantmentsStatus(enchantment, selectedStatus);
 
     }
 

--- a/src/main/java/cz/kominekjan/disenchantment/commands/impl/BookSplitEnchantments.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/impl/BookSplitEnchantments.java
@@ -64,12 +64,12 @@ public class BookSplitEnchantments {
             return;
         }
 
-        if(args.length == 2){
+        if(args.length == 2) {
             s.sendMessage(textWithPrefixError("You must specify if you want to enable/keep/cancel this enchantment"));
             return;
         }
 
-        EnchantmentStatus selectedStatus = switch (args[2].toLowerCase()){
+        EnchantmentStatus selectedStatus = switch (args[2].toLowerCase()) {
             case "enable" -> EnchantmentStatus.ENABLED;
             case "keep" -> EnchantmentStatus.KEEP;
             case "cancel" -> EnchantmentStatus.DISABLED;

--- a/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
@@ -1,6 +1,7 @@
 package cz.kominekjan.disenchantment.commands.impl;
 
 import cz.kominekjan.disenchantment.commands.Command;
+import cz.kominekjan.disenchantment.commands.ICommandExecutor;
 import cz.kominekjan.disenchantment.config.Config;
 import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import org.bukkit.ChatColor;
@@ -11,21 +12,48 @@ import org.bukkit.enchantments.Enchantment;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.setEnchantmentsStatus;
 import static cz.kominekjan.disenchantment.utils.TextUtils.*;
 
-public class Enchantments {
-    public static final Command command = new Command(
+public abstract class Enchantments implements ICommandExecutor {
+    public static final Command disenchantCommand = new Command(
             "enchantments",
             new String[]{"disenchantment.all", "disenchantment.command.enchantments"},
             "You don't have permission to use this command.",
             new String[]{},
             false,
-            Enchantments::execute
+            new Enchantments() {
+                @Override
+                public Map<Enchantment, EnchantmentStatus> getEnchantmentsStatus() {
+                    return Config.getEnchantmentsStatus();
+                }
+
+                @Override
+                public void setEnchantmentsStatus(Enchantment enchantment, EnchantmentStatus status) {
+                    Config.setEnchantmentsStatus(enchantment, status);
+                }
+            }
+    );
+    public static final Command bookSplittingCommand = new Command(
+            "split-enchantments",
+            new String[]{"disenchantment.all", "disenchantment.command.enchantments"},
+            "You don't have permission to use this command.",
+            new String[]{},
+            false,
+            new Enchantments() {
+                @Override
+                public Map<Enchantment, EnchantmentStatus> getEnchantmentsStatus() {
+                    return Config.getBookSplittingEnchantmentsStatus();
+                }
+
+                @Override
+                public void setEnchantmentsStatus(Enchantment enchantment, EnchantmentStatus status) {
+                    Config.setBookSplittingEnchantmentsStatus(enchantment, status);
+                }
+            }
     );
 
-    public static void execute(CommandSender s, String[] args) {
-        Map<Enchantment, EnchantmentStatus> enchantmentStatus = Config.getEnchantmentsStatus();
+    public void execute(CommandSender s, String[] args) {
+        Map<Enchantment, EnchantmentStatus> enchantmentStatus = getEnchantmentsStatus();
 
         if (args.length == 1) {
             s.sendMessage(textWithPrefix("Disabled enchantments"));
@@ -80,4 +108,9 @@ public class Enchantments {
         setEnchantmentsStatus(enchantment, selectedStatus);
 
     }
+
+    public abstract Map<Enchantment, EnchantmentStatus> getEnchantmentsStatus();
+
+    public abstract void setEnchantmentsStatus(Enchantment enchantment, EnchantmentStatus status);
+
 }

--- a/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
@@ -63,12 +63,12 @@ public class Enchantments {
             return;
         }
 
-        if(args.length == 2){
+        if(args.length == 2) {
             s.sendMessage(textWithPrefixError("You must specify if you want to enable/keep/cancel this enchantment"));
             return;
         }
 
-        EnchantmentStatus selectedStatus = switch (args[2].toLowerCase()){
+        EnchantmentStatus selectedStatus = switch (args[2].toLowerCase()) {
             case "enable" -> EnchantmentStatus.ENABLED;
             case "keep" -> EnchantmentStatus.KEEP;
             case "cancel" -> EnchantmentStatus.DISABLED;

--- a/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
@@ -96,7 +96,12 @@ public abstract class Enchantments implements ICommandExecutor {
             return;
         }
 
-        EnchantmentStatus selectedStatus = EnchantmentStatus.getStatusByName(args[2]);
+        EnchantmentStatus selectedStatus = switch (args[2].toLowerCase()){
+            case "enable" -> EnchantmentStatus.ENABLED;
+            case "keep" -> EnchantmentStatus.KEEP;
+            case "cancel" -> EnchantmentStatus.DISABLED;
+            default -> null;
+        };
 
         if (selectedStatus == null) {
             s.sendMessage(textWithPrefixError("You must specify if you want to enable/keep/cancel this enchantment"));

--- a/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
+++ b/src/main/java/cz/kominekjan/disenchantment/commands/impl/Enchantments.java
@@ -1,6 +1,7 @@
 package cz.kominekjan.disenchantment.commands.impl;
 
 import cz.kominekjan.disenchantment.commands.Command;
+import cz.kominekjan.disenchantment.config.Config;
 import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
@@ -10,7 +11,6 @@ import org.bukkit.enchantments.Enchantment;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.getEnchantmentStatus;
 import static cz.kominekjan.disenchantment.config.Config.setEnchantmentsStatus;
 import static cz.kominekjan.disenchantment.utils.TextUtils.*;
 
@@ -25,7 +25,7 @@ public class Enchantments {
     );
 
     public static void execute(CommandSender s, String[] args) {
-        Map<Enchantment, EnchantmentStatus> enchantmentStatus = getEnchantmentStatus();
+        Map<Enchantment, EnchantmentStatus> enchantmentStatus = Config.getEnchantmentsStatus();
 
         if (args.length == 1) {
             s.sendMessage(textWithPrefix("Disabled enchantments"));
@@ -50,7 +50,7 @@ public class Enchantments {
 
                 }
 
-                builder.append(ChatColor.GRAY + enchantment.getKey().getKey().getKey());
+                builder.append(ChatColor.GRAY).append(enchantment.getKey().getKey().getKey());
                 s.sendMessage(builder.toString());
             }
             return;

--- a/src/main/java/cz/kominekjan/disenchantment/config/Config.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/Config.java
@@ -129,8 +129,7 @@ public class Config {
      * @param status Enchantment status to be set to.
      */
     public static void setEnchantmentsStatus(@NotNull Enchantment enchantment, @NotNull EnchantmentStatus status) {
-        config.set(ConfigKeys.ENCHANTMENTS_STATUS.getKey()+"."+enchantment.getKey().getKey(), status.getConfigName());
-        plugin.saveConfig();
+        setGeneralEnchantmentStatus(ConfigKeys.ENCHANTMENTS_STATUS, enchantment, status);
     }
 
     /**
@@ -139,9 +138,32 @@ public class Config {
      * @param status Enchantment status to be set to.
      */
     public static void setBookSplittingEnchantmentsStatus(@NotNull Enchantment enchantment, @NotNull EnchantmentStatus status) {
-        config.set(ConfigKeys.BOOK_SPLITTING_ENCHANTMENTS_STATUS.getKey()+"."+enchantment.getKey().getKey(), status.getConfigName());
+        setGeneralEnchantmentStatus(ConfigKeys.BOOK_SPLITTING_ENCHANTMENTS_STATUS, enchantment, status);
+    }
+
+    private static void setGeneralEnchantmentStatus(@NotNull ConfigKeys configKey, @NotNull Enchantment enchantment, @NotNull EnchantmentStatus status){
+        String configPath = configKey.getKey()+"."+enchantment.getKey().getKey();
+
+        if(EnchantmentStatus.ENABLED == status){
+            if(!config.isString(configPath))
+                // Already absent. no need to write
+                return;
+
+            // Remove from config
+            config.set(configPath, null);
+        }
+        else {
+            if(status.getConfigName().equalsIgnoreCase(config.getString(configPath))){
+                // Same as previous value. we do not continue
+                return;
+            }
+
+            config.set(configPath, status.getConfigName());
+        }
+
         plugin.saveConfig();
     }
+
 
     public static Boolean getDisableBookSplitting() {
         return config.getBoolean(ConfigKeys.DISABLE_BOOK_SPLITTING.getKey());

--- a/src/main/java/cz/kominekjan/disenchantment/config/Config.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/Config.java
@@ -64,7 +64,9 @@ public class Config {
         }
 
         for (String enchantmentKey : section.getKeys(false)) {
-            EnchantmentStatus status = EnchantmentStatus.getStatusByName(enchantmentKey);
+            if(!section.isString(enchantmentKey)) continue;
+
+            EnchantmentStatus status = EnchantmentStatus.getStatusByName(section.getString(enchantmentKey));
             if(status == null) continue;
 
             Registry.ENCHANTMENT

--- a/src/main/java/cz/kominekjan/disenchantment/config/Config.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/Config.java
@@ -36,17 +36,6 @@ public class Config {
         return new ArrayList<>(config.getStringList(ConfigKeys.DISABLED_ITEMS.getKey()).stream().map(Material::getMaterial).toList());
     }
 
-    public static Map<Enchantment, Boolean> getDisabledEnchantments() {
-        List<String> list = config.getStringList(ConfigKeys.DISABLED_ENCHANTMENTS.getKey());
-        return list.stream().map(s -> {
-            String[] split = s.split(":");
-            return Map.entry(
-                    Objects.requireNonNull(Registry.ENCHANTMENT.stream().filter(e -> e.getKey().getKey().equals(split[0])).findFirst().orElse(null)),
-                    Boolean.parseBoolean(split[1])
-            );
-        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
     public static Map<Enchantment, EnchantmentStatus> getBookSplittingEnchantmentsStatus(){
         return getGeneralEnchantmentStatus(ConfigKeys.BOOK_SPLITTING_ENCHANTMENTS_STATUS, ConfigKeys.DISABLED_BOOK_SPLITTING_ENCHANTMENTS);
     }
@@ -122,6 +111,7 @@ public class Config {
         return getLegacyStatus(legacyKey, enchantment);
     }
 
+    // legacy (disabled-enchantment) compatibility
     private static EnchantmentStatus getLegacyStatus(ConfigKeys legacyKey, Enchantment enchantment) {
         ConfigurationSection legacySection = config.getConfigurationSection(legacyKey.getKey());
         if (legacySection == null) return EnchantmentStatus.ENABLED;

--- a/src/main/java/cz/kominekjan/disenchantment/config/Config.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/Config.java
@@ -180,13 +180,6 @@ public class Config {
         return getDisabledMaterials().equals(materials);
     }
 
-    public static Boolean setDisabledEnchantments(Map<Enchantment, Boolean> enchantments) {
-        config.set(ConfigKeys.DISABLED_ENCHANTMENTS.getKey(), enchantments.entrySet().stream().map(e -> e.getKey().getKey().getKey() + ":" + e.getValue()).toList());
-        plugin.saveConfig();
-
-        return getDisabledEnchantments().equals(enchantments);
-    }
-
     public static Boolean setEnableAnvilSound(Boolean enabled) {
         config.set(ConfigKeys.ENABLE_ANVIL_SOUND.getKey(), enabled);
         plugin.saveConfig();

--- a/src/main/java/cz/kominekjan/disenchantment/config/Config.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/Config.java
@@ -6,6 +6,7 @@ import org.bukkit.Registry;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.enchantments.Enchantment;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -100,6 +101,25 @@ public class Config {
         }
     }
 
+    /**
+     * Set enchantment status and save config file.
+     * @param enchantment Enchantment to set the status to.
+     * @param status Enchantment status to be set to.
+     */
+    public static void setEnchantmentsStatus(@NotNull Enchantment enchantment, @NotNull EnchantmentStatus status) {
+        config.set(ConfigKeys.ENCHANTMENTS_STATUS.getKey()+"."+enchantment.getKey().getKey(), status.getConfigName());
+        plugin.saveConfig();
+    }
+
+    /**
+     * Set enchantment status for book splitting and save config file.
+     * @param enchantment Enchantment to set the status to.
+     * @param status Enchantment status to be set to.
+     */
+    public static void setBookSplittingEnchantmentsStatus(@NotNull Enchantment enchantment, @NotNull EnchantmentStatus status) {
+        config.set(ConfigKeys.BOOK_SPLITTING_ENCHANTMENTS_STATUS.getKey()+"."+enchantment.getKey().getKey(), status.getConfigName());
+        plugin.saveConfig();
+    }
 
     public static Boolean getDisableBookSplitting() {
         return config.getBoolean(ConfigKeys.DISABLE_BOOK_SPLITTING.getKey());
@@ -107,17 +127,6 @@ public class Config {
 
     public static List<World> getDisabledBookSplittingWorlds() {
         return new ArrayList<>(config.getStringList(ConfigKeys.DISABLED_WORLDS.getKey()).stream().map(Bukkit::getWorld).toList());
-    }
-
-    public static Map<Enchantment, Boolean> getDisabledBookSplittingEnchantments() {
-        List<String> list = config.getStringList(ConfigKeys.DISABLED_BOOK_SPLITTING_ENCHANTMENTS.getKey());
-        return list.stream().map(s -> {
-            String[] split = s.split(":");
-            return Map.entry(
-                    Objects.requireNonNull(Registry.ENCHANTMENT.stream().filter(e -> e.getKey().getKey().equals(split[0])).findFirst().orElse(null)),
-                    Boolean.parseBoolean(split[1])
-            );
-        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public static Boolean getEnableAnvilSound() {

--- a/src/main/java/cz/kominekjan/disenchantment/config/Config.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/Config.java
@@ -36,17 +36,18 @@ public class Config {
         return new ArrayList<>(config.getStringList(ConfigKeys.DISABLED_ITEMS.getKey()).stream().map(Material::getMaterial).toList());
     }
 
-    public static Map<Enchantment, EnchantmentStatus> getBookSplittingEnchantmentsStatus(){
+    public static Map<Enchantment, EnchantmentStatus> getBookSplittingEnchantmentsStatus() {
         return getGeneralEnchantmentStatus(ConfigKeys.BOOK_SPLITTING_ENCHANTMENTS_STATUS, ConfigKeys.DISABLED_BOOK_SPLITTING_ENCHANTMENTS);
     }
 
-    public static Map<Enchantment, EnchantmentStatus> getEnchantmentsStatus(){
+    public static Map<Enchantment, EnchantmentStatus> getEnchantmentsStatus() {
         return getGeneralEnchantmentStatus(ConfigKeys.ENCHANTMENTS_STATUS, ConfigKeys.DISABLED_ENCHANTMENTS);
     }
 
-    private static Map<Enchantment, EnchantmentStatus> getGeneralEnchantmentStatus(ConfigKeys newKey, ConfigKeys legacyKey){
+    private static Map<Enchantment, EnchantmentStatus> getGeneralEnchantmentStatus(ConfigKeys newKey, ConfigKeys legacyKey) {
         Map<Enchantment, EnchantmentStatus> statuses = new HashMap<>();
         ConfigurationSection section = config.getConfigurationSection(newKey.getKey());
+
         if(section == null) {
             fillLegacyStatus(legacyKey, statuses);
             return statuses;
@@ -56,6 +57,7 @@ public class Config {
             if(!section.isString(enchantmentKey)) continue;
 
             EnchantmentStatus status = EnchantmentStatus.getStatusByName(section.getString(enchantmentKey));
+
             if(status == null) continue;
 
             Registry.ENCHANTMENT
@@ -72,14 +74,15 @@ public class Config {
     // legacy (disabled-enchantment) compatibility
     private static void fillLegacyStatus(ConfigKeys legacyKey, Map<Enchantment, EnchantmentStatus> statuses) {
         ConfigurationSection legacySection = config.getConfigurationSection(legacyKey.getKey());
+
         if (legacySection == null) return;
 
         for (String enchantmentKey : legacySection.getKeys(false)) {
             EnchantmentStatus status;
-            if(!legacySection.isBoolean(enchantmentKey)){
+            if(!legacySection.isBoolean(enchantmentKey)) {
                 // Not "false" or "true". we default to enabled
                 status = EnchantmentStatus.ENABLED;
-            }else{
+            } else {
                 status = config.getBoolean(enchantmentKey) ? EnchantmentStatus.DISABLED : EnchantmentStatus.KEEP;
             }
 
@@ -92,34 +95,38 @@ public class Config {
         }
     }
 
-    public static EnchantmentStatus getBookSplittingEnchantmentStatus(@NotNull Enchantment enchantment){
+    public static EnchantmentStatus getBookSplittingEnchantmentStatus(@NotNull Enchantment enchantment) {
         return getGeneralEnchantmentStatus(ConfigKeys.BOOK_SPLITTING_ENCHANTMENTS_STATUS, ConfigKeys.DISABLED_BOOK_SPLITTING_ENCHANTMENTS, enchantment);
     }
 
-    public static EnchantmentStatus getEnchantmentStatus(@NotNull Enchantment enchantment){
+    public static EnchantmentStatus getEnchantmentStatus(@NotNull Enchantment enchantment) {
         return getGeneralEnchantmentStatus(ConfigKeys.ENCHANTMENTS_STATUS, ConfigKeys.DISABLED_ENCHANTMENTS, enchantment);
     }
 
-    private static EnchantmentStatus getGeneralEnchantmentStatus(ConfigKeys newKey, ConfigKeys legacyKey, Enchantment enchantment){
+    private static EnchantmentStatus getGeneralEnchantmentStatus(ConfigKeys newKey, ConfigKeys legacyKey, Enchantment enchantment) {
         ConfigurationSection section = config.getConfigurationSection(newKey.getKey());
+
         if (section == null) return getLegacyStatus(legacyKey, enchantment);
 
         String toFind = enchantment.getKey().getKey();
         String key = section.getKeys(false).stream().filter(toFind::equalsIgnoreCase).findFirst().orElse(null);
 
         if(key != null) return EnchantmentStatus.getStatusByName(section.getString(key));
+
         return getLegacyStatus(legacyKey, enchantment);
     }
 
     // legacy (disabled-enchantment) compatibility
     private static EnchantmentStatus getLegacyStatus(ConfigKeys legacyKey, Enchantment enchantment) {
         ConfigurationSection legacySection = config.getConfigurationSection(legacyKey.getKey());
+
         if (legacySection == null) return EnchantmentStatus.ENABLED;
 
         String toFind = enchantment.getKey().getKey();
         String key = legacySection.getKeys(false).stream().filter(toFind::equalsIgnoreCase).findFirst().orElse(null);
 
         if((key == null) || (!legacySection.isBoolean(key))) return EnchantmentStatus.ENABLED;
+
         return legacySection.getBoolean(key) ? EnchantmentStatus.DISABLED : EnchantmentStatus.KEEP;
     }
 
@@ -144,7 +151,7 @@ public class Config {
     private static void setGeneralEnchantmentStatus(@NotNull ConfigKeys configKey, @NotNull Enchantment enchantment, @NotNull EnchantmentStatus status){
         String configPath = configKey.getKey()+"."+enchantment.getKey().getKey();
 
-        if(EnchantmentStatus.ENABLED == status){
+        if(EnchantmentStatus.ENABLED == status) {
             if(!config.isString(configPath))
                 // Already absent. no need to write
                 return;
@@ -153,7 +160,7 @@ public class Config {
             config.set(configPath, null);
         }
         else {
-            if(status.getConfigName().equalsIgnoreCase(config.getString(configPath))){
+            if(status.getConfigName().equalsIgnoreCase(config.getString(configPath))) {
                 // Same as previous value. we do not continue
                 return;
             }

--- a/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
@@ -1,6 +1,5 @@
 package cz.kominekjan.disenchantment.config;
 
-import cz.kominekjan.disenchantment.Disenchantment;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
@@ -1,21 +1,50 @@
 package cz.kominekjan.disenchantment.config;
 
+import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
+
 import javax.annotation.Nullable;
 
 public enum EnchantmentStatus {
-    ENABLED,
-    KEEP,
-    DISABLED
+    ENABLED(ChatColor.GREEN, "enabled"),
+    KEEP(ChatColor.GOLD, "keep"),
+    DISABLED(ChatColor.RED, "disabled"),
     ;
 
+    private final String displayName;
+    private final String configName;
+    EnchantmentStatus(ChatColor color, String configName) {
+        this.displayName = color + configName;
+        this.configName = configName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getConfigName() {
+        return configName;
+    }
+
     @Nullable
-    public static EnchantmentStatus getStatusByName(String name){
+    public static EnchantmentStatus getStatusByName(@NotNull String name){
         return switch (name.toLowerCase()){
             case "enabled" -> ENABLED;
             case "keep" -> KEEP;
             case "disabled" -> DISABLED;
 
             default -> null;
+        };
+    }
+
+    @NotNull
+    public static EnchantmentStatus getNextStatus(@Nullable EnchantmentStatus lastStatus){
+        if(lastStatus == null) return ENABLED;
+
+        return switch (lastStatus){
+            case ENABLED -> DISABLED;
+            case DISABLED -> KEEP;
+            case KEEP -> ENABLED;
         };
     }
 

--- a/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
@@ -1,0 +1,22 @@
+package cz.kominekjan.disenchantment.config;
+
+import javax.annotation.Nullable;
+
+public enum EnchantmentStatus {
+    ENABLED,
+    KEEP,
+    DISABLED
+    ;
+
+    @Nullable
+    public static EnchantmentStatus getStatusByName(String name){
+        return switch (name.toLowerCase()){
+            case "enabled" -> ENABLED;
+            case "keep" -> KEEP;
+            case "disabled" -> DISABLED;
+
+            default -> null;
+        };
+    }
+
+}

--- a/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
@@ -1,20 +1,21 @@
 package cz.kominekjan.disenchantment.config;
 
+import cz.kominekjan.disenchantment.Disenchantment;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 
 public enum EnchantmentStatus {
-    ENABLED(ChatColor.GREEN, "enabled"),
-    KEEP(ChatColor.GOLD, "keep"),
-    DISABLED(ChatColor.RED, "disabled"),
+    ENABLED(ChatColor.GREEN + "Enabled", "enabled"),
+    KEEP(ChatColor.GOLD + "Keep", "keep"),
+    DISABLED(ChatColor.RED + "Disabled", "disabled"),
     ;
 
     private final String displayName;
     private final String configName;
-    EnchantmentStatus(ChatColor color, String configName) {
-        this.displayName = color + configName;
+    EnchantmentStatus(String displayName, String configName) {
+        this.displayName = displayName;
         this.configName = configName;
     }
 
@@ -27,7 +28,9 @@ public enum EnchantmentStatus {
     }
 
     @Nullable
-    public static EnchantmentStatus getStatusByName(@NotNull String name){
+    public static EnchantmentStatus getStatusByName(@Nullable String name){
+        if(name == null) return null;
+
         return switch (name.toLowerCase()){
             case "enabled" -> ENABLED;
             case "keep" -> KEEP;

--- a/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.Nullable;
 
 public enum EnchantmentStatus {
-    ENABLED(ChatColor.GREEN + "Enabled", "enabled"),
+    ENABLED(ChatColor.GREEN + "Enabled", null),
     KEEP(ChatColor.GOLD + "Keep", "keep"),
     DISABLED(ChatColor.RED + "Disabled", "disabled"),
     ;

--- a/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
@@ -1,5 +1,6 @@
 package cz.kominekjan.disenchantment.config;
 
+import com.google.errorprone.annotations.Keep;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,9 +45,9 @@ public enum EnchantmentStatus {
         if(lastStatus == null) return ENABLED;
 
         return switch (lastStatus){
-            case ENABLED -> DISABLED;
-            case DISABLED -> KEEP;
-            case KEEP -> ENABLED;
+            case ENABLED -> KEEP;
+            case KEEP -> DISABLED;
+            case DISABLED -> ENABLED;
         };
     }
 

--- a/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
+++ b/src/main/java/cz/kominekjan/disenchantment/config/EnchantmentStatus.java
@@ -1,6 +1,5 @@
 package cz.kominekjan.disenchantment.config;
 
-import com.google.errorprone.annotations.Keep;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/cz/kominekjan/disenchantment/events/ItemClickEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/ItemClickEvent.java
@@ -5,7 +5,6 @@ import cz.kominekjan.disenchantment.plugins.PluginManager;
 import cz.kominekjan.disenchantment.plugins.impl.VanillaPlugin;
 import org.bukkit.Material;
 import org.bukkit.Sound;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -19,7 +18,6 @@ import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.inventory.view.AnvilView;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import static cz.kominekjan.disenchantment.Disenchantment.enabled;
 import static cz.kominekjan.disenchantment.Disenchantment.logger;

--- a/src/main/java/cz/kominekjan/disenchantment/events/ItemClickEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/ItemClickEvent.java
@@ -5,6 +5,7 @@ import cz.kominekjan.disenchantment.plugins.PluginManager;
 import cz.kominekjan.disenchantment.plugins.impl.VanillaPlugin;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -13,10 +14,12 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.inventory.view.AnvilView;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static cz.kominekjan.disenchantment.Disenchantment.enabled;
 import static cz.kominekjan.disenchantment.Disenchantment.logger;
@@ -55,6 +58,8 @@ public class ItemClickEvent implements Listener {
         if (!isEventValidDisenchantItem(firstItem, secondItem)) return;
 
         AnvilView anvilView = (AnvilView) e.getView();
+
+        EnchantmentStorageMeta resultItemMeta = (EnchantmentStorageMeta) result.getItemMeta();
 
         if (anvilView.getRepairCost() > p.getLevel() && p.getGameMode() != org.bukkit.GameMode.CREATIVE) {
             e.setCancelled(true);
@@ -99,11 +104,11 @@ public class ItemClickEvent implements Listener {
         boolean atLeastOnePluginEnabled = false;
 
         for (IPlugin plugin : activatedPlugins.values()) {
-            item = plugin.removeAllEnchantments(firstItem);
+            item = plugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
             atLeastOnePluginEnabled = true;
         }
 
-        if (!atLeastOnePluginEnabled) item = VanillaPlugin.removeAllEnchantments(firstItem);
+        if (!atLeastOnePluginEnabled) item = VanillaPlugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
 
         // Disenchantment plugins
         // ----------------------------------------------------------------------------------------------------
@@ -114,8 +119,6 @@ public class ItemClickEvent implements Listener {
         }
 
         anvilInventory.setItem(0, item);
-
-        if (secondItem == null) return;
 
         if (secondItem.getAmount() > 1) {
             secondItem.setAmount(secondItem.getAmount() - 1);

--- a/src/main/java/cz/kominekjan/disenchantment/events/ItemClickEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/ItemClickEvent.java
@@ -99,14 +99,15 @@ public class ItemClickEvent implements Listener {
 
         HashMap<String, IPlugin> activatedPlugins = PluginManager.getActivatedPlugins();
 
-        boolean atLeastOnePluginEnabled = false;
+        if(activatedPlugins.isEmpty()) {
+            item = VanillaPlugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
 
-        for (IPlugin plugin : activatedPlugins.values()) {
-            item = plugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
-            atLeastOnePluginEnabled = true;
+        } else {
+            for (IPlugin plugin : activatedPlugins.values()) {
+                item = plugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
+            }
+
         }
-
-        if (!atLeastOnePluginEnabled) item = VanillaPlugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
 
         // Disenchantment plugins
         // ----------------------------------------------------------------------------------------------------

--- a/src/main/java/cz/kominekjan/disenchantment/events/ItemEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/ItemEvent.java
@@ -59,14 +59,15 @@ public class ItemEvent implements Listener {
 
         HashMap<String, IPlugin> activatedPlugins = PluginManager.getActivatedPlugins();
 
-        boolean atLeastOnePluginEnabled = false;
+        if(activatedPlugins.isEmpty()) {
+            book = VanillaPlugin.createEnchantedBook(enchantments);
 
-        for (IPlugin plugin : activatedPlugins.values()) {
-            book = plugin.createEnchantedBook(enchantments);
-            atLeastOnePluginEnabled = true;
+        } else {
+            for (IPlugin plugin : activatedPlugins.values()) {
+                book = plugin.createEnchantedBook(enchantments);
+            }
+
         }
-
-        if (!atLeastOnePluginEnabled) book = VanillaPlugin.createEnchantedBook(enchantments);
 
         // Disenchantment plugins
         // ----------------------------------------------------------------------------------------------------

--- a/src/main/java/cz/kominekjan/disenchantment/events/ItemEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/ItemEvent.java
@@ -1,6 +1,7 @@
 package cz.kominekjan.disenchantment.events;
 
 import cz.kominekjan.disenchantment.Disenchantment;
+import cz.kominekjan.disenchantment.config.Config;
 import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import cz.kominekjan.disenchantment.plugins.IPlugin;
 import cz.kominekjan.disenchantment.plugins.PluginManager;
@@ -20,7 +21,6 @@ import java.util.HashMap;
 
 import static cz.kominekjan.disenchantment.Disenchantment.enabled;
 import static cz.kominekjan.disenchantment.config.Config.getDisabledWorlds;
-import static cz.kominekjan.disenchantment.config.Config.getEnchantmentStatus;
 import static cz.kominekjan.disenchantment.utils.AnvilCostUtils.countAnvilCost;
 import static cz.kominekjan.disenchantment.utils.EventCheckUtils.isEventValidDisenchantItem;
 
@@ -45,7 +45,7 @@ public class ItemEvent implements Listener {
         HashMap<Enchantment, Integer> enchantments = new HashMap<>(firstItem.getEnchantments());
 
         // Find enchantment to keep to remove them to result
-        getEnchantmentStatus().forEach((enchantment, status) ->{
+        Config.getEnchantmentsStatus().forEach((enchantment, status) ->{
             if(EnchantmentStatus.KEEP.equals(status))
                 enchantments.remove(enchantment);
         });

--- a/src/main/java/cz/kominekjan/disenchantment/events/ItemEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/ItemEvent.java
@@ -1,6 +1,7 @@
 package cz.kominekjan.disenchantment.events;
 
 import cz.kominekjan.disenchantment.Disenchantment;
+import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import cz.kominekjan.disenchantment.plugins.IPlugin;
 import cz.kominekjan.disenchantment.plugins.PluginManager;
 import cz.kominekjan.disenchantment.plugins.impl.VanillaPlugin;
@@ -16,12 +17,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.view.AnvilView;
 
 import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 import static cz.kominekjan.disenchantment.Disenchantment.enabled;
-import static cz.kominekjan.disenchantment.config.Config.getDisabledEnchantments;
 import static cz.kominekjan.disenchantment.config.Config.getDisabledWorlds;
+import static cz.kominekjan.disenchantment.config.Config.getEnchantmentStatus;
 import static cz.kominekjan.disenchantment.utils.AnvilCostUtils.countAnvilCost;
 import static cz.kominekjan.disenchantment.utils.EventCheckUtils.isEventValidDisenchantItem;
 
@@ -45,15 +44,11 @@ public class ItemEvent implements Listener {
 
         HashMap<Enchantment, Integer> enchantments = new HashMap<>(firstItem.getEnchantments());
 
-        for (Map.Entry<Enchantment, Boolean> disabledEnchantment : getDisabledEnchantments().entrySet()) {
-            if (!disabledEnchantment.getValue()) continue;
-
-            if (enchantments.keySet().stream().anyMatch(m -> m.equals(disabledEnchantment.getKey()))) {
-                Optional<Enchantment> enchantment = enchantments.keySet().stream().filter(m -> m.equals(disabledEnchantment.getKey())).findFirst();
-
-                enchantment.ifPresent(enchantments::remove);
-            }
-        }
+        // Find enchantment to keep to remove them to result
+        getEnchantmentStatus().forEach((enchantment, status) ->{
+            if(EnchantmentStatus.KEEP.equals(status))
+                enchantments.remove(enchantment);
+        });
 
         if (enchantments.isEmpty()) return;
 

--- a/src/main/java/cz/kominekjan/disenchantment/events/SplitBookClickEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/SplitBookClickEvent.java
@@ -100,15 +100,15 @@ public class SplitBookClickEvent implements Listener {
 
         HashMap<String, IPlugin> activatedPlugins = PluginManager.getActivatedPlugins();
 
-        boolean atLeastOnePluginEnabled = false;
+        if(activatedPlugins.isEmpty()) {
+            item = VanillaPlugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
 
-        for (IPlugin plugin : activatedPlugins.values()) {
-            item = plugin.removeEnchantments(firstItem, resultItemMeta.getStoredEnchants());
-            atLeastOnePluginEnabled = true;
+        } else {
+            for (IPlugin plugin : activatedPlugins.values()) {
+                item = plugin.removeEnchantments(item, resultItemMeta.getStoredEnchants());
+            }
+
         }
-
-        if (!atLeastOnePluginEnabled)
-            item = VanillaPlugin.removeEnchantments(firstItem, resultItemMeta.getStoredEnchants());
 
         // Disenchantment plugins
         // ----------------------------------------------------------------------------------------------------

--- a/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
@@ -1,6 +1,7 @@
 package cz.kominekjan.disenchantment.events;
 
 import cz.kominekjan.disenchantment.Disenchantment;
+import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import cz.kominekjan.disenchantment.plugins.IPlugin;
 import cz.kominekjan.disenchantment.plugins.PluginManager;
 import cz.kominekjan.disenchantment.plugins.impl.VanillaPlugin;
@@ -16,7 +17,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.view.AnvilView;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 import static cz.kominekjan.disenchantment.Disenchantment.enabled;
 import static cz.kominekjan.disenchantment.config.Config.*;
@@ -46,15 +50,10 @@ public class SplitBookEvent implements Listener {
 
         HashMap<Enchantment, Integer> enchantments = new HashMap<>(firstItemItemMeta.getStoredEnchants());
 
-        for (Map.Entry<Enchantment, Boolean> disabledEnchantment : getDisabledBookSplittingEnchantments().entrySet()) {
-            if (!disabledEnchantment.getValue()) continue;
-
-            if (enchantments.keySet().stream().anyMatch(m -> m.equals(disabledEnchantment.getKey()))) {
-                Optional<Enchantment> enchantment = enchantments.keySet().stream().filter(m -> m.equals(disabledEnchantment.getKey())).findFirst();
-
-                enchantment.ifPresent(enchantments::remove);
-            }
-        }
+        getBookSplittingEnchantmentStatus().forEach((enchantment, status) ->{
+            if(EnchantmentStatus.KEEP.equals(status))
+                enchantments.remove(enchantment);
+        });
 
         if (enchantments.isEmpty() || enchantments.size() == 1) return;
 

--- a/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
@@ -77,14 +77,15 @@ public class SplitBookEvent implements Listener {
 
         HashMap<String, IPlugin> activatedPlugins = PluginManager.getActivatedPlugins();
 
-        boolean atLeastOnePluginEnabled = false;
+        if(activatedPlugins.isEmpty()) {
+            book = VanillaPlugin.createEnchantedBook(enchantments);
 
-        for (IPlugin plugin : activatedPlugins.values()) {
-            book = plugin.createEnchantedBook(randomEnchantmentSplit);
-            atLeastOnePluginEnabled = true;
+        } else {
+            for (IPlugin plugin : activatedPlugins.values()) {
+                book = plugin.createEnchantedBook(enchantments);
+            }
+
         }
-
-        if (!atLeastOnePluginEnabled) book = VanillaPlugin.createEnchantedBook(randomEnchantmentSplit);
 
         // Disenchantment plugins
         // ----------------------------------------------------------------------------------------------------

--- a/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
@@ -49,13 +49,14 @@ public class SplitBookEvent implements Listener {
         EnchantmentStorageMeta firstItemItemMeta = (EnchantmentStorageMeta) firstItem.getItemMeta();
 
         HashMap<Enchantment, Integer> enchantments = new HashMap<>(firstItemItemMeta.getStoredEnchants());
+        if(enchantments.size() < 2) return;
 
         getBookSplittingEnchantmentsStatus().forEach((enchantment, status) ->{
             if(EnchantmentStatus.KEEP.equals(status))
                 enchantments.remove(enchantment);
         });
 
-        if (enchantments.isEmpty() || enchantments.size() == 1) return;
+        if (enchantments.isEmpty()) return;
 
         HashMap<Enchantment, Integer> randomEnchantmentSplit = new HashMap<>();
 
@@ -63,6 +64,7 @@ public class SplitBookEvent implements Listener {
         Collections.shuffle(keys); // Shuffle the keys to ensure randomness
 
         int halfSize = keys.size() / 2; // Calculate half of the size
+        if(halfSize == 0) halfSize = 1;
         for (int i = 0; i < halfSize; i++) {
             Enchantment key = keys.get(i);
             randomEnchantmentSplit.put(key, enchantments.get(key));

--- a/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
+++ b/src/main/java/cz/kominekjan/disenchantment/events/SplitBookEvent.java
@@ -50,7 +50,7 @@ public class SplitBookEvent implements Listener {
 
         HashMap<Enchantment, Integer> enchantments = new HashMap<>(firstItemItemMeta.getStoredEnchants());
 
-        getBookSplittingEnchantmentStatus().forEach((enchantment, status) ->{
+        getBookSplittingEnchantmentsStatus().forEach((enchantment, status) ->{
             if(EnchantmentStatus.KEEP.equals(status))
                 enchantments.remove(enchantment);
         });

--- a/src/main/java/cz/kominekjan/disenchantment/guis/GUIItem.java
+++ b/src/main/java/cz/kominekjan/disenchantment/guis/GUIItem.java
@@ -1,12 +1,16 @@
 package cz.kominekjan.disenchantment.guis;
 
+import cz.kominekjan.disenchantment.Disenchantment;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.security.DigestInputStream;
 
 public class GUIItem {
     private final Integer slot;
     private final ItemStack item;
     private final IOnClick onClick;
+    private long lastClick = 0;
 
     public GUIItem(int slot, ItemStack item, IOnClick onClick) {
         this.slot = slot;
@@ -23,6 +27,15 @@ public class GUIItem {
     }
 
     public void onClick(InventoryClickEvent event) {
+        // avoid double-clicking
+        long timeMilli = System.currentTimeMillis();
+        if(timeMilli - lastClick < 100) {
+            event.setCancelled(true);
+            return;
+        }
+        Disenchantment.logger.info("test: "+lastClick+" "+timeMilli);
+        lastClick = timeMilli;
+
         this.onClick.onClick(event);
     }
 }

--- a/src/main/java/cz/kominekjan/disenchantment/guis/GUIItem.java
+++ b/src/main/java/cz/kominekjan/disenchantment/guis/GUIItem.java
@@ -33,7 +33,6 @@ public class GUIItem {
             event.setCancelled(true);
             return;
         }
-        Disenchantment.logger.info("test: "+lastClick+" "+timeMilli);
         lastClick = timeMilli;
 
         this.onClick.onClick(event);

--- a/src/main/java/cz/kominekjan/disenchantment/guis/ItemBuilder.java
+++ b/src/main/java/cz/kominekjan/disenchantment/guis/ItemBuilder.java
@@ -12,8 +12,6 @@ import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.ArrayList;
 
-import static org.bukkit.inventory.ItemFlag.*;
-
 public class ItemBuilder {
     protected ItemStack stack;
 

--- a/src/main/java/cz/kominekjan/disenchantment/guis/ItemBuilder.java
+++ b/src/main/java/cz/kominekjan/disenchantment/guis/ItemBuilder.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class ItemBuilder {
     protected ItemStack stack;
@@ -83,7 +84,7 @@ public class ItemBuilder {
         return this;
     }
 
-    public ItemBuilder setLore(ArrayList<String> lore) {
+    public ItemBuilder setLore(List<String> lore) {
         ItemMeta meta = this.getItemMeta();
         meta.setLore(lore);
         this.setItemMeta(meta);

--- a/src/main/java/cz/kominekjan/disenchantment/guis/impl/DefaultGUIElements.java
+++ b/src/main/java/cz/kominekjan/disenchantment/guis/impl/DefaultGUIElements.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 public class DefaultGUIElements {
     public static void cancelOnClick(InventoryClickEvent event) {
@@ -269,12 +270,12 @@ public class DefaultGUIElements {
         return headWorldItem(name, texture, new ArrayList<>(Collections.singletonList(lore)));
     }
 
-    public static ItemStack enchantmentItem(String name, ArrayList<String> lore) {
+    public static ItemStack enchantmentItem(String name, List<String> lore) {
         return new ItemBuilder(Material.ENCHANTED_BOOK).setDisplayName(name).setLore(lore).addAllFlags().build();
     }
 
-    public static ItemStack enchantmentItem(String name, String lore) {
-        return enchantmentItem(name, new ArrayList<>(Collections.singletonList(lore)));
+    public static ItemStack enchantmentItem(String name, String... lore) {
+        return enchantmentItem(name, List.of(lore));
     }
 
     public static ItemStack disabledAnvilSoundItem() {

--- a/src/main/java/cz/kominekjan/disenchantment/guis/impl/EnchantmentsGUI.java
+++ b/src/main/java/cz/kominekjan/disenchantment/guis/impl/EnchantmentsGUI.java
@@ -1,6 +1,5 @@
 package cz.kominekjan.disenchantment.guis.impl;
 
-import cz.kominekjan.disenchantment.Disenchantment;
 import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import cz.kominekjan.disenchantment.guis.GUIItem;
 import cz.kominekjan.disenchantment.guis.InventoryBuilder;
@@ -92,7 +91,7 @@ public class EnchantmentsGUI implements InventoryHolder {
 
         GUIItem[] worldItems = new GUIItem[pageSize];
 
-        Map<Enchantment, EnchantmentStatus> statuses = getEnchantmentStatus();
+        Map<Enchantment, EnchantmentStatus> statuses = getEnchantmentsStatus();
 
         for (int i = 0; i < pageSize; i++) {
             int slot = i + this.page * 28;
@@ -111,7 +110,7 @@ public class EnchantmentsGUI implements InventoryHolder {
                     event -> {
                         event.setCancelled(true);
 
-                        EnchantmentStatus oldStatus = getEnchantmentStatus().getOrDefault(enchantment, EnchantmentStatus.ENABLED);
+                        EnchantmentStatus oldStatus = getEnchantmentStatus(enchantment);
                         EnchantmentStatus newStatus = EnchantmentStatus.getNextStatus(oldStatus);
 
                         String newLore = newStatus.getDisplayName();

--- a/src/main/java/cz/kominekjan/disenchantment/guis/impl/EnchantmentsGUI.java
+++ b/src/main/java/cz/kominekjan/disenchantment/guis/impl/EnchantmentsGUI.java
@@ -127,12 +127,14 @@ public class EnchantmentsGUI implements InventoryHolder {
                         String newLore  = newStatus.getDisplayName() + " " + ChatColor.GRAY + "for " + ChatColor.LIGHT_PURPLE + ChatColor.BOLD + "Disenchantment";
                         String newLore2 = bookNewStatus.getDisplayName() + " " + ChatColor.GRAY + "for " + ChatColor.LIGHT_PURPLE + ChatColor.BOLD + "Book Splitting";
 
-                        if(bookSplitting){
+                        if(bookSplitting) {
                             setBookSplittingEnchantmentsStatus(enchantment, bookNewStatus);
                             oldBookStatus.set(bookNewStatus);
-                        }else{
+
+                        } else {
                             setEnchantmentsStatus(enchantment, newStatus);
                             oldBookStatus.set(newStatus);
+
                         }
 
                         event.setCurrentItem(DefaultGUIElements.enchantmentItem(ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + enchantment.getKey().getKey(), newLore, newLore2));

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/IPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/IPlugin.java
@@ -12,5 +12,4 @@ public interface IPlugin {
 
     ItemStack removeEnchantments(ItemStack firstItem, Map<Enchantment, Integer> enchantments);
 
-    ItemStack removeAllEnchantments(ItemStack firstItem);
 }

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/AdvancedPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/AdvancedPlugin.java
@@ -27,17 +27,10 @@ public class AdvancedPlugin implements IPlugin {
 
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
             Enchantment enchantment = entry.getKey();
-
-            if (getDisabledEnchantments().containsKey(enchantment))
-                continue;
-
             AEAPI.removeEnchantment(item, enchantment.getKey().getKey());
         }
 
         return item;
     }
 
-    public ItemStack removeAllEnchantments(ItemStack firstItem) {
-        return this.removeEnchantments(firstItem, firstItem.getEnchantments());
-    }
 }

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/AdvancedPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/AdvancedPlugin.java
@@ -8,8 +8,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.getDisabledEnchantments;
-
 public class AdvancedPlugin implements IPlugin {
     public static final String name = "AdvancedEnchantments";
 

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/EcoPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/EcoPlugin.java
@@ -7,7 +7,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.getDisabledEnchantments;
 import static cz.kominekjan.disenchantment.utils.DisenchantUtils.removeStoredEnchantment;
 
 public class EcoPlugin implements IPlugin {

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/EcoPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/EcoPlugin.java
@@ -30,17 +30,10 @@ public class EcoPlugin implements IPlugin {
 
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
             Enchantment enchantment = entry.getKey();
-
-            if (getDisabledEnchantments().containsKey(enchantment))
-                continue;
-
             removeStoredEnchantment(item, enchantment);
         }
 
         return item;
     }
 
-    public ItemStack removeAllEnchantments(ItemStack firstItem) {
-        return this.removeEnchantments(firstItem, firstItem.getEnchantments());
-    }
 }

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/ExcellentPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/ExcellentPlugin.java
@@ -26,17 +26,10 @@ public class ExcellentPlugin implements IPlugin {
 
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
             Enchantment enchantment = entry.getKey();
-
-            if (getDisabledEnchantments().containsKey(enchantment))
-                continue;
-
             EnchantUtils.remove(item, enchantment);
         }
 
         return item;
     }
 
-    public ItemStack removeAllEnchantments(ItemStack firstItem) {
-        return this.removeEnchantments(firstItem, firstItem.getEnchantments());
-    }
 }

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/ExcellentPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/ExcellentPlugin.java
@@ -8,8 +8,6 @@ import su.nightexpress.excellentenchants.enchantment.util.EnchantUtils;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.getDisabledEnchantments;
-
 public class ExcellentPlugin implements IPlugin {
     public static final String name = "ExcellentEnchants";
 

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/SquaredPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/SquaredPlugin.java
@@ -8,8 +8,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.getDisabledEnchantments;
-
 public class SquaredPlugin implements IPlugin {
     public static final String name = "EnchantsSquared";
 

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/SquaredPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/SquaredPlugin.java
@@ -26,17 +26,10 @@ public class SquaredPlugin implements IPlugin {
 
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
             Enchantment enchantment = entry.getKey();
-
-            if (getDisabledEnchantments().containsKey(enchantment))
-                continue;
-
             CustomEnchantManager.getInstance().removeEnchant(item, enchantment.getKey().getKey());
         }
 
         return item;
     }
 
-    public ItemStack removeAllEnchantments(ItemStack firstItem) {
-        return this.removeEnchantments(firstItem, firstItem.getEnchantments());
-    }
 }

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/UberPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/UberPlugin.java
@@ -26,17 +26,10 @@ public class UberPlugin implements IPlugin {
 
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
             Enchantment enchantment = entry.getKey();
-
-            if (getDisabledEnchantments().containsKey(enchantment))
-                continue;
-
             EnchantmentUtils.removeEnchantment(enchantment, item);
         }
 
         return item;
     }
 
-    public ItemStack removeAllEnchantments(ItemStack firstItem) {
-        return this.removeEnchantments(firstItem, firstItem.getEnchantments());
-    }
 }

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/UberPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/UberPlugin.java
@@ -8,8 +8,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.getDisabledEnchantments;
-
 public class UberPlugin implements IPlugin {
     public static final String name = "UberEnchant";
 

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/VanillaPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/VanillaPlugin.java
@@ -7,7 +7,6 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Map;
 
-import static cz.kominekjan.disenchantment.config.Config.getDisabledEnchantments;
 import static cz.kominekjan.disenchantment.utils.DisenchantUtils.removeStoredEnchantment;
 
 public class VanillaPlugin {

--- a/src/main/java/cz/kominekjan/disenchantment/plugins/impl/VanillaPlugin.java
+++ b/src/main/java/cz/kominekjan/disenchantment/plugins/impl/VanillaPlugin.java
@@ -24,17 +24,10 @@ public class VanillaPlugin {
 
         for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
             Enchantment enchantment = entry.getKey();
-
-            if (getDisabledEnchantments().containsKey(enchantment))
-                continue;
-
             removeStoredEnchantment(item, enchantment);
         }
 
         return item;
     }
 
-    public static ItemStack removeAllEnchantments(ItemStack firstItem) {
-        return removeEnchantments(firstItem, firstItem.getEnchantments());
-    }
 }

--- a/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
+++ b/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
@@ -1,32 +1,42 @@
 package cz.kominekjan.disenchantment.utils;
 
+import cz.kominekjan.disenchantment.Disenchantment;
 import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static cz.kominekjan.disenchantment.config.Config.*;
 
 public class EventCheckUtils {
 
-    public static boolean checkForDisabledEnchantments(ItemStack item, Map<Enchantment, EnchantmentStatus> statuses) {
-        for (Enchantment enchantment : item.getEnchantments().keySet()) {
+    public static boolean checkForDisabledEnchantments(Set<Enchantment> enchantments, Map<Enchantment, EnchantmentStatus> statuses) {
+        for (Enchantment enchantment : enchantments) {
             EnchantmentStatus status = statuses.getOrDefault(enchantment, EnchantmentStatus.ENABLED);
 
-            if(status == EnchantmentStatus.DISABLED) return true;
+            Disenchantment.logger.info("checking "+enchantment);
+
+            if(status == EnchantmentStatus.DISABLED) {
+
+                Disenchantment.logger.info("disabled");
+                return true;
+            }
         }
 
         return false;
     }
 
-    public static boolean itemCheckForDisabled(ItemStack item) {
+    private static boolean itemCheckForDisabled(ItemStack item) {
         if (getDisabledMaterials().stream().anyMatch(m -> m.equals(item.getType())))
             return true;
 
-        return checkForDisabledEnchantments(item, getEnchantmentsStatus());
+        return checkForDisabledEnchantments(item.getEnchantments().keySet(), getEnchantmentsStatus());
     }
 
     public static boolean isEventValidDisenchantItem(ItemStack firstItem, ItemStack secondItem) {
@@ -41,8 +51,11 @@ public class EventCheckUtils {
         return !firstItem.getEnchantments().isEmpty();
     }
 
-    public static boolean splitBookCheckForDisabled(ItemStack item) {
-        return checkForDisabledEnchantments(item, getBookSplittingEnchantmentsStatus());
+    private static boolean splitBookCheckForDisabled(ItemStack item) {
+        // Assume item is an enchanted book
+        EnchantmentStorageMeta meta = (EnchantmentStorageMeta) item.getItemMeta();
+
+        return checkForDisabledEnchantments(meta.getStoredEnchants().keySet(), getBookSplittingEnchantmentsStatus());
     }
 
     public static boolean isEventValidDisenchantSplitBook(ItemStack firstItem, ItemStack secondItem) {

--- a/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
+++ b/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
@@ -20,13 +20,8 @@ public class EventCheckUtils {
         for (Enchantment enchantment : enchantments) {
             EnchantmentStatus status = statuses.getOrDefault(enchantment, EnchantmentStatus.ENABLED);
 
-            Disenchantment.logger.info("checking "+enchantment);
-
-            if(status == EnchantmentStatus.DISABLED) {
-
-                Disenchantment.logger.info("disabled");
+            if(status == EnchantmentStatus.DISABLED)
                 return true;
-            }
         }
 
         return false;

--- a/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
+++ b/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
@@ -23,10 +23,10 @@ public class EventCheckUtils {
     }
 
     public static boolean itemCheckForDisabled(ItemStack item) {
-        if (getDisabledMaterials().stream().anyMatch(m -> m.getKey().getKey().equalsIgnoreCase(item.getType().getKey().getKey())))
+        if (getDisabledMaterials().stream().anyMatch(m -> m.equals(item.getType())))
             return true;
 
-        return checkForDisabledEnchantments(item, getEnchantmentStatus());
+        return checkForDisabledEnchantments(item, getEnchantmentsStatus());
     }
 
     public static boolean isEventValidDisenchantItem(ItemStack firstItem, ItemStack secondItem) {
@@ -42,7 +42,7 @@ public class EventCheckUtils {
     }
 
     public static boolean splitBookCheckForDisabled(ItemStack item) {
-        return checkForDisabledEnchantments(item, getBookSplittingEnchantmentStatus());
+        return checkForDisabledEnchantments(item, getBookSplittingEnchantmentsStatus());
     }
 
     public static boolean isEventValidDisenchantSplitBook(ItemStack firstItem, ItemStack secondItem) {

--- a/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
+++ b/src/main/java/cz/kominekjan/disenchantment/utils/EventCheckUtils.java
@@ -1,34 +1,32 @@
 package cz.kominekjan.disenchantment.utils;
 
+import cz.kominekjan.disenchantment.config.EnchantmentStatus;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
-import java.util.List;
 import java.util.Map;
 
 import static cz.kominekjan.disenchantment.config.Config.*;
 
 public class EventCheckUtils {
+
+    public static boolean checkForDisabledEnchantments(ItemStack item, Map<Enchantment, EnchantmentStatus> statuses) {
+        for (Enchantment enchantment : item.getEnchantments().keySet()) {
+            EnchantmentStatus status = statuses.getOrDefault(enchantment, EnchantmentStatus.ENABLED);
+
+            if(status == EnchantmentStatus.DISABLED) return true;
+        }
+
+        return false;
+    }
+
     public static boolean itemCheckForDisabled(ItemStack item) {
         if (getDisabledMaterials().stream().anyMatch(m -> m.getKey().getKey().equalsIgnoreCase(item.getType().getKey().getKey())))
             return true;
 
-        boolean cancel = false;
-
-        for (Map.Entry<Enchantment, Boolean> disabledEnchantment : getDisabledEnchantments().entrySet()) {
-            if (disabledEnchantment.getValue()) continue;
-
-            List<Enchantment> itemEnchantments = item.getEnchantments().keySet().stream().toList();
-
-            if (itemEnchantments.contains(disabledEnchantment.getKey())) {
-                cancel = true;
-                break;
-            }
-        }
-
-        return cancel;
+        return checkForDisabledEnchantments(item, getEnchantmentStatus());
     }
 
     public static boolean isEventValidDisenchantItem(ItemStack firstItem, ItemStack secondItem) {
@@ -44,20 +42,7 @@ public class EventCheckUtils {
     }
 
     public static boolean splitBookCheckForDisabled(ItemStack item) {
-        boolean cancel = false;
-
-        for (Map.Entry<Enchantment, Boolean> disabledEnchantment : getDisabledBookSplittingEnchantments().entrySet()) {
-            if (disabledEnchantment.getValue()) continue;
-
-            List<Enchantment> itemEnchantments = item.getEnchantments().keySet().stream().toList();
-
-            if (itemEnchantments.contains(disabledEnchantment.getKey())) {
-                cancel = true;
-                break;
-            }
-        }
-
-        return cancel;
+        return checkForDisabledEnchantments(item, getBookSplittingEnchantmentStatus());
     }
 
     public static boolean isEventValidDisenchantSplitBook(ItemStack firstItem, ItemStack secondItem) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,7 +23,8 @@ disabled-materials: [ ]
 enchantments-status:
   # Here is example of how it should look like.
   # enchantments can take value "enabled", "keep" and "disabled"
-  sharpness: enabled
+  # for example:
+  #sharpness: enabled
 
 
 # ----------------------------------------------------------------------------------------
@@ -41,7 +42,8 @@ disabled-book-splitting-worlds: [ ]
 book-splitting-enchantments-status:
   # Here is example of how it should look like.
   # enchantments can take value "enabled", "keep" and "disabled"
-  sharpness: enabled
+  # for example:
+  #sharpness: enabled
 
 
 # ----------------------------------------------------------------------------------------

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,11 +1,11 @@
 # Enable or disable the plugin
-"enabled": true
+enabled: true
 
 # Enable or disable the log
-"enable-logging": true
+enable-logging: true
 
 # Logging level: INFO, DEBUG
-"logging-level": "INFO"
+logging-level: "INFO"
 
 
 # ----------------------------------------------------------------------------------------
@@ -14,13 +14,16 @@
 
 
 # List of worlds where the plugin is disabled
-"disabled-worlds": [ ]
+disabled-worlds: [ ]
 
 # List of materials that are not allowed to be disenchanted
-"disabled-materials": [ ]
+disabled-materials: [ ]
 
-# List of enchantments that are not allowed to be disenchanted
-"disabled-enchantments": [ ]
+# List of enchantments status for item disenchantment.
+enchantments-status:
+  # Here is example of how it should look like.
+  # enchantments can take value "enabled", "keep" and "disabled"
+  sharpness: enabled
 
 
 # ----------------------------------------------------------------------------------------
@@ -29,13 +32,16 @@
 
 
 # Enable or disable the book splitting
-"disable-book-splitting": false
+disable-book-splitting: false
 
 # List of worlds where the book splitting is disabled
-"disabled-book-splitting-worlds": [ ]
+disabled-book-splitting-worlds: [ ]
 
-# List of enchantments that are not allowed to be split
-"disabled-book-splitting-enchantments": [ ]
+# List of enchantments status for book splitting
+book-splitting-enchantments-status:
+  # Here is example of how it should look like.
+  # enchantments can take value "enabled", "keep" and "disabled"
+  sharpness: enabled
 
 
 # ----------------------------------------------------------------------------------------
@@ -44,11 +50,11 @@
 
 
 # Enable or disable the anvil sound
-"enable-anvil-sound": true
+enable-anvil-sound: true
 
 # Edit the volume and pitch of the anvil sound
-"anvil-volume": 1.0
-"anvil-pitch": 1.0
+anvil-volume: 1.0
+anvil-pitch: 1.0
 
 
 # ----------------------------------------------------------------------------------------
@@ -57,13 +63,13 @@
 
 
 # Enable or disable the repair cost reset back to 0 when the item is disenchanted
-"enable-repair-reset": false
+enable-repair-reset: false
 
 # Enable or disable the repair cost
-"enable-repair-cost": true
+enable-repair-cost: true
 
 # Base value for the cost of the disenchantment
-"base": 10
+base: 10
 
 # This multiplication is applied to the base value
 # The enchantments are sorted by level in descending order, so the more enchantments you have, the more expensive it is
@@ -76,4 +82,4 @@
 #
 #   10 + (1 * 1) = 11  ->  11 + (5 * 1.25) = 17.25  ->  17.25
 #
-"multiply": 0.25
+multiply: 0.25


### PR DESCRIPTION
Change previous system using "disabled-enchantments" and "disabled-book-splitting-enchantments" and replace it with a more explicit system of enchantment "status" ("enchantments-status" & "book-splitting-enchantments-status")
status of an enchantment can be "enabled", "keep" or "disabled".
If status is absent it will check previous system to check enchantment status then default to "enabled". (Therefore not breaking current config)

Enchantment GUI now work as expected and allow changing book splitting enchantment behavior by right-clicking.
(changing disenchantment enchantment behavior only work with left click now)
Removed most unintended double-clicking on GUI.

Added command for book splitting enchantment status

close #14

The only issue I have is with the "ConfigUpdater" where is seems to not like my system. What is it for ?
