### PR TITLE
[FIX] EcoEnchants V13, MC 26.1.x support, Geyser AnvilView crash

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -10,6 +10,7 @@ This FAQ addresses common issues and questions regarding the Disenchantment plug
 - [I'm using GeyserMC and the plugin has issues.](#im-using-geysermc-and-the-plugin-has-issues-is-this-a-known-problem)
 - [Economy is enabled but players aren't being charged.](#economy-is-enabled-but-players-arent-being-charged)
 - [Do I need Vault for the plugin to work?](#do-i-need-vault-for-the-plugin-to-work)
+- [Does Disenchantment support Minecraft 26.1.x?](#does-disenchantment-support-minecraft-261x)
 
 ---
 
@@ -27,27 +28,8 @@ See the full list of permission nodes in [PERMISSIONS.md](PERMISSIONS.md).
 
 ### Why isn't Disenchantment working with EcoEnchants?
 
-This is a known compatibility issue caused by how **EcoEnchants** handles anvil events, which conflicts with *
-*Disenchantment**. The enchanted book appears in the anvil for a moment before vanishing.
-
-To fix this, you need to update **Disenchantment** and use a modified version of **EcoEnchants**.
-
-**Easiest Solution (Recommended)**
-
-1. Update the **Disenchantment** plugin to version **`6.2.2`** or newer.
-2. Download the pre-compiled, fixed version of **EcoEnchants** (v12.24.0) from
-   the [Disenchantment v6.2.2 release page](https://github.com/H7KZ/Disenchantment/releases/tag/v6.2.2).
-
-You must use both the updated Disenchantment plugin and the provided EcoEnchants `.jar` file for the fix to work.
-
-**Alternative for Advanced Users**
-
-If you're comfortable with compiling Java projects, you can build the plugin yourself:
-
-1. Make sure your **Disenchantment** plugin is updated to **`v6.2.2`** or newer.
-2. Clone or download the **EcoEnchants** source code.
-3. Incorporate the changes from [EcoEnchants Pull Request #417](https://github.com/Auxilor/EcoEnchants/pull/417).
-4. Compile the plugin to create your own `.jar` file.
+EcoEnchants V13.0.0 is fully supported natively as of **Disenchantment 6.4.0**. No patched build of EcoEnchants is
+required. Simply update Disenchantment to version **`6.4.0`** or newer and use any standard release of EcoEnchants.
 
 ---
 
@@ -92,14 +74,18 @@ installed. All standard disenchanting and book splitting features work without i
 
 ### I'm using GeyserMC and the plugin has issues. Is this a known problem?
 
-Yes, servers running GeyserMC can sometimes experience issues with plugins that modify anvil mechanics, especially for
-players connecting from Bedrock Edition. This is often caused by Geyser itself rather than a bug in Disenchantment.
+As of **Disenchantment 6.4.0+**, Geyser clients are handled gracefully. The `ClassCastException` that previously
+crashed anvil interactions for Bedrock players has been fixed in all v1_21_R* NMS modules.
 
-While a guaranteed fix is not available, you can try installing one of the following plugins designed to patch
-anvil-related issues on Geyser servers:
+Bedrock clients connected via Geyser will be able to use the anvil without errors. However, the anvil cost display
+(repair cost shown in the UI) may be inaccurate for Bedrock clients, as Geyser's proxy `InventoryView` does not
+support cost propagation via the `AnvilView` API. This is a known limitation of the Geyser proxy layer and cannot be
+worked around on the server side.
 
-- [Geyser-Anvil-Fix](https://github.com/ssquadteam/Geyser-Anvil-Fix)
-- [CustomAnvilGUI](https://www.spigotmc.org/resources/customanvilgui.116411/)
-- [Geyser Recipe Fix](https://modrinth.com/plugin/geyser-recipe-fix)
+---
 
-**Note:** As reported by some users, these fixes may not work in all cases.
+### Does Disenchantment support Minecraft 26.1.x?
+
+Yes. Minecraft 26.1.1 and later 26.1.x patch releases are supported. Explicit enum entries exist for 26.1, 26.1.1,
+26.1.2, and 26.1.3 in `MinecraftVersion.java`, and all are routed to the `v1_21_R5` NMS module (the same module used
+by LATEST). Any 26.x.x version that is not yet listed explicitly is also handled by the LATEST fallback.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,7 @@ Get the latest release from any of these sources:
 | [Vane](https://modrinth.com/plugin/vane)                         |         ✓         |        ✓        |       ✓       |        -        |       -       |
 | [Zenchantments](https://github.com/moikheck/Zenchantments)       |         ✓         |        ✓        |       ✓       |        -        |       -       |
 
-> **Note:** EcoEnchants requires a patched build. See [EcoEnchants#417](https://github.com/Auxilor/EcoEnchants/pull/417)
-> for details, or download the pre-built v12.24.0 from
-> the [v6.2.2 release](https://github.com/H7KZ/Disenchantment/releases/tag/v6.2.2).
+> **Note:** EcoEnchants V13.0.0 is supported natively with Disenchantment 6.4.0+. No patched build is required.
 
 ## Documentation
 

--- a/core/src/main/java/com/jankominek/disenchantment/nms/MinecraftVersion.java
+++ b/core/src/main/java/com/jankominek/disenchantment/nms/MinecraftVersion.java
@@ -13,6 +13,12 @@ public enum MinecraftVersion {
     LATEST((byte) 127, null, null, "v1_21_R5"),
 
 
+    // 26_1 (mapped to v1_21_R5 via LATEST fallback)
+    MINECRAFT_26_1_3((byte) 29, "26_1_3", "26.1.3", "v1_21_R5"),
+    MINECRAFT_26_1_2((byte) 28, "26_1_2", "26.1.2", "v1_21_R5"),
+    MINECRAFT_26_1_1((byte) 27, "26_1_1", "26.1.1", "v1_21_R5"),
+    MINECRAFT_26_1((byte) 26, "26_1", "26.1", "v1_21_R5"),
+
     // 1_21_R5
     MINECRAFT_1_21_11((byte) 25, "1_21_11", "1.21.11", "v1_21_R5"),
     MINECRAFT_1_21_10((byte) 25, "1_21_10", "1.21.10", "v1_21_R5"),
@@ -82,6 +88,18 @@ public enum MinecraftVersion {
             if (version.versionDotted == null) continue;
             if (v.contains(version.versionDotted))
                 return version;
+        }
+
+        // Extract numeric MC version from "git-Paper-xxx (MC: 26.1.1)" or bare "1.21.8" / "1_21_8".
+        // Covers both future major-version schemes (26.x.x) and unknown 1.21+ patch releases.
+        try {
+            java.util.regex.Matcher m = java.util.regex.Pattern.compile("MC: (\\d+)\\.(\\d+)").matcher(v);
+            if (m.find()) {
+                int major = Integer.parseInt(m.group(1));
+                int minor = Integer.parseInt(m.group(2));
+                if (major >= 2 || minor >= 21) return LATEST;
+            }
+        } catch (Exception ignored) {
         }
 
         try {

--- a/v1_18_R1/src/main/java/plugins/EcoEnchants_v1_18_R1.java
+++ b/v1_18_R1/src/main/java/plugins/EcoEnchants_v1_18_R1.java
@@ -7,6 +7,7 @@ import com.jankominek.disenchantment.utils.SchedulerUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
@@ -14,6 +15,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredListener;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -108,8 +110,25 @@ public class EcoEnchants_v1_18_R1 implements ISupportedPlugin {
 
     /**
      * {@inheritDoc}
-     * Delays activation to re-register EcoEnchants' PrepareAnvilEvent listener
-     * so that it fires before Disenchantment's own listener.
+     *
+     * <p>Schedules a delayed task to fix EcoEnchants 13+ anvil event ordering.
+     *
+     * <p>EcoEnchants 13 introduced two breaking changes for third-party anvil plugins:
+     * <ol>
+     *   <li>Its {@link PrepareAnvilEvent} handler at HIGHEST synchronously clears the result
+     *       slot, then re-computes it asynchronously. For disenchant operations (enchanted item
+     *       + blank book) the async result is FAIL, so it leaves the slot alone — meaning
+     *       Disenchantment's result survives as long as EcoEnchants fires <em>first</em>.
+     *       Since Disenchantment declares EcoEnchants as a soft-dependency, EcoEnchants always
+     *       loads (and registers its listeners) before Disenchantment, giving us the correct
+     *       natural order with no extra work needed here.</li>
+     *   <li>Its {@link InventoryClickEvent} handler at HIGHEST cancels any click on anvil slot 2
+     *       that EcoEnchants did not produce itself (by comparing generation counters). This
+     *       prevents Disenchantment from ever processing its own results. Re-registering all
+     *       EcoEnchants click listeners to the end of the handler list lets Disenchantment run
+     *       first; by the time EcoEnchants tries to cancel, the item is already on the player's
+     *       cursor.</li>
+     * </ol></p>
      */
     public void activate() {
         SchedulerUtils.runGlobal(plugin, this::delayActivation);
@@ -139,16 +158,40 @@ public class EcoEnchants_v1_18_R1 implements ISupportedPlugin {
         }
 
         if (ecoListener == null) {
-            // Avoid sending warning if CustomAnvil is present as it disable the listener itself
-            if (pm.isPluginEnabled("CustomAnvil")) return;
+            // Avoid sending warning if CustomAnvil is present as it disables the listener itself
+            if (!pm.isPluginEnabled("CustomAnvil")) {
+                logger.warning("Could not find eco enchant pre anvil listener");
+            }
+        } else {
+            // unregister then re register event so it is executed before disenchantment events
+            preAnvilHandler.unregister(ecoListener);
+            preAnvilHandler.register(ecoListener);
+        }
 
-            logger.warning("Could not find eco enchant pre anvil listener");
+        // Re-register all EcoEnchants InventoryClickEvent listeners to fire after Disenchantment.
+        // EcoEnchants 13+ cancels clicks on anvil slot 2 that it didn't produce, blocking
+        // Disenchantment from processing its own results. Firing after Disenchantment means
+        // Disenchantment handles the click first; EcoEnchants' cancellation is then a no-op.
+        List<RegisteredListener> ecoClickListeners = new ArrayList<>();
+        HandlerList clickHandler = InventoryClickEvent.getHandlerList();
+
+        for (RegisteredListener listener : clickHandler.getRegisteredListeners()) {
+            if (ecoEnchant == listener.getPlugin()) {
+                ecoClickListeners.add(listener);
+            }
+        }
+
+        if (ecoClickListeners.isEmpty()) {
+            if (!pm.isPluginEnabled("CustomAnvil")) {
+                logger.warning("Could not find EcoEnchants click listener");
+            }
 
             return;
         }
 
-        // unregister then re register event so it is executed before disenchantment events
-        preAnvilHandler.unregister(ecoListener);
-        preAnvilHandler.register(ecoListener);
+        for (RegisteredListener listener : ecoClickListeners) {
+            clickHandler.unregister(listener);
+            clickHandler.register(listener);
+        }
     }
 }

--- a/v1_20_R4/src/main/java/plugins/EcoEnchants_v1_20_R4.java
+++ b/v1_20_R4/src/main/java/plugins/EcoEnchants_v1_20_R4.java
@@ -7,6 +7,7 @@ import com.jankominek.disenchantment.utils.SchedulerUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
@@ -14,6 +15,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredListener;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -108,8 +110,25 @@ public class EcoEnchants_v1_20_R4 implements ISupportedPlugin {
 
     /**
      * {@inheritDoc}
-     * Delays activation to re-register EcoEnchants' PrepareAnvilEvent listener
-     * so that it fires before Disenchantment's own listener.
+     *
+     * <p>Schedules a delayed task to fix EcoEnchants 13+ anvil event ordering.
+     *
+     * <p>EcoEnchants 13 introduced two breaking changes for third-party anvil plugins:
+     * <ol>
+     *   <li>Its {@link PrepareAnvilEvent} handler at HIGHEST synchronously clears the result
+     *       slot, then re-computes it asynchronously. For disenchant operations (enchanted item
+     *       + blank book) the async result is FAIL, so it leaves the slot alone — meaning
+     *       Disenchantment's result survives as long as EcoEnchants fires <em>first</em>.
+     *       Since Disenchantment declares EcoEnchants as a soft-dependency, EcoEnchants always
+     *       loads (and registers its listeners) before Disenchantment, giving us the correct
+     *       natural order with no extra work needed here.</li>
+     *   <li>Its {@link InventoryClickEvent} handler at HIGHEST cancels any click on anvil slot 2
+     *       that EcoEnchants did not produce itself (by comparing generation counters). This
+     *       prevents Disenchantment from ever processing its own results. Re-registering all
+     *       EcoEnchants click listeners to the end of the handler list lets Disenchantment run
+     *       first; by the time EcoEnchants tries to cancel, the item is already on the player's
+     *       cursor.</li>
+     * </ol></p>
      */
     public void activate() {
         SchedulerUtils.runGlobal(plugin, this::delayActivation);
@@ -139,16 +158,40 @@ public class EcoEnchants_v1_20_R4 implements ISupportedPlugin {
         }
 
         if (ecoListener == null) {
-            // Avoid sending warning if CustomAnvil is present as it disable the listener itself
-            if (pm.isPluginEnabled("CustomAnvil")) return;
+            // Avoid sending warning if CustomAnvil is present as it disables the listener itself
+            if (!pm.isPluginEnabled("CustomAnvil")) {
+                logger.warning("Could not find eco enchant pre anvil listener");
+            }
+        } else {
+            // unregister then re register event so it is executed before disenchantment events
+            preAnvilHandler.unregister(ecoListener);
+            preAnvilHandler.register(ecoListener);
+        }
 
-            logger.warning("Could not find eco enchant pre anvil listener");
+        // Re-register all EcoEnchants InventoryClickEvent listeners to fire after Disenchantment.
+        // EcoEnchants 13+ cancels clicks on anvil slot 2 that it didn't produce, blocking
+        // Disenchantment from processing its own results. Firing after Disenchantment means
+        // Disenchantment handles the click first; EcoEnchants' cancellation is then a no-op.
+        List<RegisteredListener> ecoClickListeners = new ArrayList<>();
+        HandlerList clickHandler = InventoryClickEvent.getHandlerList();
+
+        for (RegisteredListener listener : clickHandler.getRegisteredListeners()) {
+            if (ecoEnchant == listener.getPlugin()) {
+                ecoClickListeners.add(listener);
+            }
+        }
+
+        if (ecoClickListeners.isEmpty()) {
+            if (!pm.isPluginEnabled("CustomAnvil")) {
+                logger.warning("Could not find EcoEnchants click listener");
+            }
 
             return;
         }
 
-        // unregister then re register event so it is executed before disenchantment events
-        preAnvilHandler.unregister(ecoListener);
-        preAnvilHandler.register(ecoListener);
+        for (RegisteredListener listener : ecoClickListeners) {
+            clickHandler.unregister(listener);
+            clickHandler.register(listener);
+        }
     }
 }

--- a/v1_21_R1/src/main/java/com/jankominek/disenchantment/nms/NMS_v1_21_R1.java
+++ b/v1_21_R1/src/main/java/com/jankominek/disenchantment/nms/NMS_v1_21_R1.java
@@ -84,9 +84,13 @@ public class NMS_v1_21_R1 implements NMS {
      */
     @Override
     public int getRepairCost(AnvilInventory anvilInventory, InventoryView inventoryView) {
-        AnvilView anvilView = (AnvilView) inventoryView;
+        try {
+            AnvilView anvilView = (AnvilView) inventoryView;
 
-        return anvilView.getRepairCost();
+            return anvilView.getRepairCost();
+        } catch (ClassCastException e) {
+            return anvilInventory.getRepairCost();
+        }
     }
 
     /**
@@ -105,9 +109,12 @@ public class NMS_v1_21_R1 implements NMS {
      */
     @Override
     public void setAnvilRepairCost(AnvilInventory anvilInventory, InventoryView inventoryView, int repairCost) {
-        AnvilView anvilView = (AnvilView) inventoryView;
+        try {
+            AnvilView anvilView = (AnvilView) inventoryView;
 
-        anvilView.setRepairCost(repairCost);
+            anvilView.setRepairCost(repairCost);
+        } catch (ClassCastException ignored) {
+        }
     }
 
     /**

--- a/v1_21_R1/src/main/java/plugins/EcoEnchants_v1_21_R1.java
+++ b/v1_21_R1/src/main/java/plugins/EcoEnchants_v1_21_R1.java
@@ -7,6 +7,7 @@ import com.jankominek.disenchantment.utils.SchedulerUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
@@ -14,6 +15,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredListener;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -119,8 +121,24 @@ public class EcoEnchants_v1_21_R1 implements ISupportedPlugin {
     /**
      * {@inheritDoc}
      *
-     * <p>Schedules a delayed task to re-register the EcoEnchants {@link PrepareAnvilEvent}
-     * listener so that it fires before the Disenchantment listener.</p>
+     * <p>Schedules a delayed task to fix EcoEnchants 13+ anvil event ordering.
+     *
+     * <p>EcoEnchants 13 introduced two breaking changes for third-party anvil plugins:
+     * <ol>
+     *   <li>Its {@link PrepareAnvilEvent} handler at HIGHEST synchronously clears the result
+     *       slot, then re-computes it asynchronously. For disenchant operations (enchanted item
+     *       + blank book) the async result is FAIL, so it leaves the slot alone — meaning
+     *       Disenchantment's result survives as long as EcoEnchants fires <em>first</em>.
+     *       Since Disenchantment declares EcoEnchants as a soft-dependency, EcoEnchants always
+     *       loads (and registers its listeners) before Disenchantment, giving us the correct
+     *       natural order with no extra work needed here.</li>
+     *   <li>Its {@link InventoryClickEvent} handler at HIGHEST cancels any click on anvil slot 2
+     *       that EcoEnchants did not produce itself (by comparing generation counters). This
+     *       prevents Disenchantment from ever processing its own results. Re-registering all
+     *       EcoEnchants click listeners to the end of the handler list lets Disenchantment run
+     *       first; by the time EcoEnchants tries to cancel, the item is already on the player's
+     *       cursor.</li>
+     * </ol></p>
      */
     public void activate() {
         SchedulerUtils.runGlobal(plugin, this::delayActivation);
@@ -150,16 +168,40 @@ public class EcoEnchants_v1_21_R1 implements ISupportedPlugin {
         }
 
         if (ecoListener == null) {
-            // Avoid sending warning if CustomAnvil is present as it disable the listener itself
-            if (pm.isPluginEnabled("CustomAnvil")) return;
+            // Avoid sending warning if CustomAnvil is present as it disables the listener itself
+            if (!pm.isPluginEnabled("CustomAnvil")) {
+                logger.warning("Could not find eco enchant pre anvil listener");
+            }
+        } else {
+            // unregister then re register event so it is executed before disenchantment events
+            preAnvilHandler.unregister(ecoListener);
+            preAnvilHandler.register(ecoListener);
+        }
 
-            logger.warning("Could not find eco enchant pre anvil listener");
+        // Re-register all EcoEnchants InventoryClickEvent listeners to fire after Disenchantment.
+        // EcoEnchants 13+ cancels clicks on anvil slot 2 that it didn't produce, blocking
+        // Disenchantment from processing its own results. Firing after Disenchantment means
+        // Disenchantment handles the click first; EcoEnchants' cancellation is then a no-op.
+        List<RegisteredListener> ecoClickListeners = new ArrayList<>();
+        HandlerList clickHandler = InventoryClickEvent.getHandlerList();
+
+        for (RegisteredListener listener : clickHandler.getRegisteredListeners()) {
+            if (ecoEnchant == listener.getPlugin()) {
+                ecoClickListeners.add(listener);
+            }
+        }
+
+        if (ecoClickListeners.isEmpty()) {
+            if (!pm.isPluginEnabled("CustomAnvil")) {
+                logger.warning("Could not find EcoEnchants click listener");
+            }
 
             return;
         }
 
-        // unregister then re register event so it is executed before disenchantment events
-        preAnvilHandler.unregister(ecoListener);
-        preAnvilHandler.register(ecoListener);
+        for (RegisteredListener listener : ecoClickListeners) {
+            clickHandler.unregister(listener);
+            clickHandler.register(listener);
+        }
     }
 }

--- a/v1_21_R4/src/main/java/com/jankominek/disenchantment/nms/NMS_v1_21_R4.java
+++ b/v1_21_R4/src/main/java/com/jankominek/disenchantment/nms/NMS_v1_21_R4.java
@@ -84,9 +84,13 @@ public class NMS_v1_21_R4 implements NMS {
      */
     @Override
     public int getRepairCost(AnvilInventory anvilInventory, InventoryView inventoryView) {
-        AnvilView anvilView = (AnvilView) inventoryView;
+        try {
+            AnvilView anvilView = (AnvilView) inventoryView;
 
-        return anvilView.getRepairCost();
+            return anvilView.getRepairCost();
+        } catch (ClassCastException e) {
+            return anvilInventory.getRepairCost();
+        }
     }
 
     /**
@@ -105,9 +109,12 @@ public class NMS_v1_21_R4 implements NMS {
      */
     @Override
     public void setAnvilRepairCost(AnvilInventory anvilInventory, InventoryView inventoryView, int repairCost) {
-        AnvilView anvilView = (AnvilView) inventoryView;
+        try {
+            AnvilView anvilView = (AnvilView) inventoryView;
 
-        anvilView.setRepairCost(repairCost);
+            anvilView.setRepairCost(repairCost);
+        } catch (ClassCastException ignored) {
+        }
     }
 
     /**

--- a/v1_21_R5/src/main/java/com/jankominek/disenchantment/nms/NMS_v1_21_R5.java
+++ b/v1_21_R5/src/main/java/com/jankominek/disenchantment/nms/NMS_v1_21_R5.java
@@ -84,9 +84,13 @@ public class NMS_v1_21_R5 implements NMS {
      */
     @Override
     public int getRepairCost(AnvilInventory anvilInventory, InventoryView inventoryView) {
-        AnvilView anvilView = (AnvilView) inventoryView;
+        try {
+            AnvilView anvilView = (AnvilView) inventoryView;
 
-        return anvilView.getRepairCost();
+            return anvilView.getRepairCost();
+        } catch (ClassCastException e) {
+            return anvilInventory.getRepairCost();
+        }
     }
 
     /**
@@ -105,9 +109,12 @@ public class NMS_v1_21_R5 implements NMS {
      */
     @Override
     public void setAnvilRepairCost(AnvilInventory anvilInventory, InventoryView inventoryView, int repairCost) {
-        AnvilView anvilView = (AnvilView) inventoryView;
+        try {
+            AnvilView anvilView = (AnvilView) inventoryView;
 
-        anvilView.setRepairCost(repairCost);
+            anvilView.setRepairCost(repairCost);
+        } catch (ClassCastException ignored) {
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #64 — EcoEnchants V13.0.0: backport InventoryClickEvent re-registration to v1_21_R1, v1_20_R4, v1_18_R1 adapters. EcoEnchants 13+ cancels anvil slot-2 clicks it didn't produce; re-registering its listeners to the end of the handler list lets Disenchantment fire first. Also fixed CustomAnvil early-return guard that was skipping the click re-registration entirely. No patched EcoEnchants build required.

Closes #65 — MC 26.1.x: add explicit enum entries for 26.1–26.1.3 in MinecraftVersion. Replace broken split(".")[0] fallback with regex extraction of "MC: X.Y" from the Paper version string, fixing future unknown 26.x versions being mapped to INCOMPATIBLE instead of LATEST.

Closes #66 — Geyser compatibility: wrap AnvilView cast in try-catch in all v1_21_R* NMS modules. Geyser proxy does not extend AnvilView; bare cast threw ClassCastException, silently breaking all anvil interactions for Bedrock clients. Fallback to AnvilInventory.getRepairCost() for get; silent no-op for set.